### PR TITLE
Add rustdoc build & publish to github pages workflow, other small tweaks

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -59,7 +59,7 @@ jobs:
     name: cargo-deny
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
 
   # TODO: Remove this check if you don't publish the crate(s) from this repo
@@ -67,7 +67,7 @@ jobs:
     name: Publish Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
@@ -115,7 +115,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install -y musl-tools
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - run: cargo fetch --target ${{ matrix.target }}
       - name: Release build
         shell: bash
@@ -170,7 +170,7 @@ jobs:
     needs: [test, deny-check]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx

--- a/.github/workflows/rustdoc-pages.yml
+++ b/.github/workflows/rustdoc-pages.yml
@@ -5,10 +5,12 @@
 # You must also go to the Pages settings for your repo and set it to serve from Actions for this to work
 name: Publish Docs
 
-on:
-  workflow_dispatch:
-  push:
-    branches: [ "main" ]
+# TODO: Replace this line with the commented ones to actually run the action in your repo(s)
+on: public
+# on:
+#   workflow_dispatch:
+#   push:
+#     branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rustdoc-pages.yml
+++ b/.github/workflows/rustdoc-pages.yml
@@ -1,0 +1,62 @@
+# Publishes docs built off latest git main branch to a GitHub Pages site.
+# The docs root will then be served at https://$YOUR_USERNAME.github.io/$REPO_NAME/$CRATE_NAME/index.html
+# For example, https://embarkstudios.github.io/presser/presser/index.html
+#
+# You must also go to the Pages settings for your repo and set it to serve from Actions for this to work
+name: Publish Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build Docs
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Rust Env
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+    - name: Build Docs
+      run: RUSTDOCFLAGS="--cfg docs_build" cargo doc
+    - name: Setup Pages
+      id: pages
+      uses: actions/configure-pages@v2
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        # Upload entire doc folder
+        path: './target/doc'
+
+  deploy:
+    name: Deploy to Pages
+  
+    needs: build
+    
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,7 +4,16 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
+      - "#review-threads-unresolved=0"
       - base=main
+      - label!=block-automerge
+      # TODO: If you're not a Rust project and aren't using the bundled rust-ci workflows,
+      # remove these or change them to the relevant CI job names:
+      - check-success=Lint
+      - check-success=Build & Test (ubuntu-latest)
+      - check-success=Build & Test (windows-latest)
+      - check-success=Build & Test (macOS-latest)
+      - check-success=Publish Check
     actions:
       merge:
         method: squash

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 [![Embark](https://img.shields.io/badge/discord-ark-%237289da.svg?logo=discord)](https://discord.gg/dAuKfZS)
 [![Crates.io](https://img.shields.io/crates/v/rust-gpu.svg)](https://crates.io/crates/rust-gpu)
 [![Docs](https://docs.rs/rust-gpu/badge.svg)](https://docs.rs/rust-gpu)
+[![Git Docs](https://img.shields.io/badge/git%20main%20docs-published-blue)](https://embarkstudios.github.io/presser/presser/index.html)
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/rust-gpu/status.svg)](https://deps.rs/repo/github/EmbarkStudios/rust-gpu)
 [![Build status](https://github.com/EmbarkStudios/physx-rs/workflows/CI/badge.svg)](https://github.com/EmbarkStudios/physx-rs/actions)
 </div>
@@ -28,6 +29,7 @@
 1. **Title:** Change the first line of this README to the name of your project, and replace the sunflower with an emoji that represents your project. 🚨 Your emoji selection is critical.
 1. **Badges:** In the badges section above, change the repo name in each URL. If you are creating something other than a Rust crate, remove the crates.io and docs badges (and feel free to add more appropriate ones for your language).
 1. **CI:** In `./github/workflows/` rename `rust-ci.yml` (or the appropriate config for your language) to `ci.yml`. And go over it and adapt it to work for your project
+    - If you aren't using or customized the CI workflow, also see the TODO in `.mergify.yml`
 1. **CHANGELOG.md:** Change the `$REPO_NAME` in the links at the bottom to the name of the repository, and replace the example template lines with the actual notes for the repository/crate.
 1. **release.toml:** in `./release.toml` change the `$REPO_NAME` to the name of the repository
 1. **Cleanup:** Remove this section of the README and any unused files (such as configs for other languages) from the repo.

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Any contribution intentionally submitted for inclusion in an Embark Studios proj
 
 This contribution is dual licensed under EITHER OF
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 1. **Badges:** In the badges section above, change the repo name in each URL. If you are creating something other than a Rust crate, remove the crates.io and docs badges (and feel free to add more appropriate ones for your language).
 1. **CI:** In `./github/workflows/` rename `rust-ci.yml` (or the appropriate config for your language) to `ci.yml`. And go over it and adapt it to work for your project
     - If you aren't using or customized the CI workflow, also see the TODO in `.mergify.yml`
+    - If you want to use the automatic rustdoc publishing to github pages for git main, see `rustdoc-pages.yml`
 1. **Issue & PR Templates**: Review the files in `.github/ISSUE_TEMPLATE` and `.github/pull_request_template`. Adapt them
 to suit your needs, removing or re-wording any sections that don't make sense for your use case.
 1. **CHANGELOG.md:** Change the `$REPO_NAME` in the links at the bottom to the name of the repository, and replace the example template lines with the actual notes for the repository/crate.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 1. **Badges:** In the badges section above, change the repo name in each URL. If you are creating something other than a Rust crate, remove the crates.io and docs badges (and feel free to add more appropriate ones for your language).
 1. **CI:** In `./github/workflows/` rename `rust-ci.yml` (or the appropriate config for your language) to `ci.yml`. And go over it and adapt it to work for your project
     - If you aren't using or customized the CI workflow, also see the TODO in `.mergify.yml`
+1. **Issue & PR Templates**: Review the files in `.github/ISSUE_TEMPLATE` and `.github/pull_request_template`. Adapt them
+to suit your needs, removing or re-wording any sections that don't make sense for your use case.
 1. **CHANGELOG.md:** Change the `$REPO_NAME` in the links at the bottom to the name of the repository, and replace the example template lines with the actual notes for the repository/crate.
 1. **release.toml:** in `./release.toml` change the `$REPO_NAME` to the name of the repository
 1. **Cleanup:** Remove this section of the README and any unused files (such as configs for other languages) from the repo.


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

A few tweaks from using this in https://github.com/EmbarkStudios/presser

- Adds a github action workflow template which builds and publishes latest documentation from main to github pages
- Updates some old action workflow versions
- Updates the mergify config to block on unresolved comments and explicitly check the default github actions CI jobs
